### PR TITLE
Prepare guide for "depoy on PWS" feature

### DIFF
--- a/run-on-pws.json
+++ b/run-on-pws.json
@@ -1,0 +1,33 @@
+{
+    "orgName": "spring-guides",
+    "orgUuid": "",
+    "spaces": [
+        {
+            "name": "spring-guides",
+            "routes": [
+                {
+                    "name": "random1",
+                    "value": "${random-word}"
+                }
+            ],
+            "apps": [
+                {
+                    "name": "rest-service",
+                    "code": {
+                        "url": "https://springio-guides.s3.amazonaws.com/gs-rest-service-0.1.0.jar",
+                        "content_type": "application/war",
+                        "actions": [
+                            "push"
+                        ]
+                    },
+                    "instances": 1,
+                    "memory_in_mb": 1024,
+                    "disk_in_mb": 1024,
+                    "map_routes": [
+                        "random1"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,4 +1,20 @@
 cd $(dirname $0)
+cd ../initial
+
+mvn clean compile
+ret=$?
+if [ $ret -ne 0 ]; then
+exit $ret
+fi
+rm -rf target
+
+./gradlew compileJava
+ret=$?
+if [ $ret -ne 0 ]; then
+exit $ret
+fi
+rm -rf build
+
 cd ../complete
 mvn clean package
 java -jar target/gs-rest-service-0.1.0.jar &
@@ -19,6 +35,14 @@ if diff -w ../test/expected.json target/actual.json
         let ret=255
         exit $ret
 fi
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
+  then 
+    curl https://raw.githubusercontent.com/timkay/aws/master/aws -o aws
+    chmod u+x aws
+    ./aws put --progress "x-amz-acl: public-read" springio-guides/gs-rest-service-0.1.0.jar target/gs-rest-service-0.1.0.jar
+fi
+
 rm -rf target
 
 ./gradlew build
@@ -26,22 +50,6 @@ ret=$?
 if [ $ret -ne 0 ]; then
 exit $ret
 fi
+
 rm -rf build
-
-cd ../initial
-
-mvn clean compile
-ret=$?
-if [ $ret -ne 0 ]; then
-exit $ret
-fi
-rm -rf target
-
-./gradlew compileJava
-ret=$?
-if [ $ret -ne 0 ]; then
-exit $ret
-fi
-rm -rf build
-
 exit


### PR DESCRIPTION
This Pull Request adds the following:

* push app artifact on S3 in CI script
* add a metadata file "run-on-pws.json" for the deploy agent
to read the app configuration from

TODO before integrating this PR:

* add the S3 account credentials as a Travis hidden environment variables `EC2_ACCESS_KEY` and `EC2_SECRET_KEY`
* revisit this PR to make those changes "guide-agnostic"

Here's an example of [a descriptor example, with multiple apps and services](https://github.com/asaikali/spring-music-war/blob/master/run-on-pws.json).