### PR TITLE
Add link to execute the guide in a browser IDE (using Codenvy)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,9 @@ projects: [spring-framework]
 :icons: font
 :source-highlighter: prettify
 
+image:http://beta.codenvy.com/factory/resources/codenvy-contribute.svg["Codenvy Developer Workspace", link="http://beta.codenvy.com/f?id=9fq0busbm3tz7i8c"]
+
+
 This guide walks you through the process of creating a "hello world" link:/understanding/REST[RESTful web service] with Spring.
 
 == What you'll build


### PR DESCRIPTION
It's nice to see all the steps that we have to do, but it requires for example
- JDK 1.8 or later
- Gradle 2.3+ or Maven 3.0+
- git to clone the project or download and extract a zip file

whereas here, by using the following button, we only have to click on it ("Workspace Developer" button)
then we can try and develop spring rest service from the web browser.

Note: I may add some instructions for explaining how it works but it's mainly clicking on the button.

![image](https://cloud.githubusercontent.com/assets/436777/15654449/a76ae45c-2694-11e6-975c-b97082a805ee.png)
as you can see, the guide is displayed on the right and complete project is started so it can be tested by clicking on "preview url" link.