### PR TITLE
Replaced deprecated 'spring-boot' plugin

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
-apply plugin: 'spring-boot'
+apply plugin: 'org.springframework.boot'
 
 jar {
     baseName = 'gs-rest-service'


### PR DESCRIPTION
Gradle build notes that 'spring-boot' is deprecated and to use 'org.springframework.boot' instead.
![gradle_build](https://cloud.githubusercontent.com/assets/22287411/20420084/5f74762c-ad9e-11e6-9c87-cc2c382dd9fc.png)
