### PR TITLE
Remove jsonpath dependency which it's unnecessary since the newer versions use Jackon by default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,53 +82,6 @@ include::initial/build.gradle[]
 ----
 ====
 
-=== Adding a JSON Library
-
-Because you will use JSON to send and receive information, you need a JSON library. In
-this guide, you will use the Jayway JsonPath library.
-
-To include the library in a Maven build, add the following dependency to your `pom.xml`
-file:
-
-====
-[source,xml]
-----
-<dependency>
-  <groupId>com.jayway.jsonpath</groupId>
-  <artifactId>json-path</artifactId>
-  <scope>test</scope>
-</dependency>
-----
-====
-
-The following listing shows the finished `pom.xml` file:
-
-====
-[source,xml]
-----
-include::complete/pom.xml[]
-----
-====
-
-To include the libary in a Gradle build, add the following dependency to your
-`build.gradle` file:
-
-====
-[source,text]
-----
-testCompile 'com.jayway.jsonpath:json-path'
-----
-====
-
-The following listing shows the finished `build.gradle` file:
-
-====
-[source,text]
-----
-include::complete/build.gradle[]
-----
-====
-
 [[initial]]
 == Create a Resource Representation Class
 

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -14,7 +14,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testCompile 'com.jayway.jsonpath:json-path'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -23,11 +23,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		<dependency>
-		  <groupId>com.jayway.jsonpath</groupId>
-		  <artifactId>json-path</artifactId>
-		  <scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
By merging this commit the Adding a JSON Library part will be removed. The idea is to make the article as simple as possible for beginners.