### PR TITLE
Uppercase static final constants

### DIFF
--- a/complete-kotlin/src/main/kotlin/com/example/restservice/GreetingController.kt
+++ b/complete-kotlin/src/main/kotlin/com/example/restservice/GreetingController.kt
@@ -10,12 +10,12 @@ import org.springframework.web.bind.annotation.RestController
 class GreetingController {
 
     companion object {
-        private const val template = "Hello, %s!"
+        private const val TEMPLATE = "Hello, %s!"
     }
     private val counter = AtomicLong()
 
     @GetMapping("/greeting")
     fun greeting(@RequestParam name: String = "World") =
-        Greeting(counter.incrementAndGet(), String.format(template, name))
+        Greeting(counter.incrementAndGet(), String.format(TEMPLATE, name))
 
 }

--- a/complete/src/main/java/com/example/restservice/GreetingController.java
+++ b/complete/src/main/java/com/example/restservice/GreetingController.java
@@ -9,11 +9,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class GreetingController {
 
-	private static final String template = "Hello, %s!";
+	private static final String TEMPLATE = "Hello, %s!";
 	private final AtomicLong counter = new AtomicLong();
 
 	@GetMapping("/greeting")
 	public Greeting greeting(@RequestParam(defaultValue = "World") String name) {
-		return new Greeting(counter.incrementAndGet(), String.format(template, name));
+		return new Greeting(counter.incrementAndGet(), String.format(TEMPLATE, name));
 	}
 }


### PR DESCRIPTION
Right now both the Java as well as Kotlin implementation doesn't follow the correct naming convention for `template` in `GreetingController`. This results in a warning in IDE. 
<img width="883" height="442" alt="Screenshot 2025-07-24 at 7 07 05 AM" src="https://github.com/user-attachments/assets/55bff186-1c72-48c6-b45a-33a03eb5a4ba" />

Fixing this as it uppercase naming convention applies both for `private static final` in Java & constants in Kotlin.
https://kotlinlang.org/docs/coding-conventions.html#property-names