### PR TITLE
Clarify RestServiceApplication is guide-specific, not Initializr default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -162,8 +162,11 @@ is automatically chosen to convert the `Greeting` instance to JSON.
 
 == Run the Service
 
-The Spring Initializr creates an application class for you. In this case, you do not need
-to further modify the class. The following listing shows the `RestServiceApplication` application class:
+The https://start.spring.io[Spring Initializr] creates an application class for you.
+For the purpose of this guide, the sample project uses the package `com.example.restservice`
+and the class name `RestServiceApplication`.
+
+The following listing shows the application class used in this tutorial:
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]
 .Java


### PR DESCRIPTION
This PR updates the "Run the Service" section in `README.adoc` to clarify that the `RestServiceApplication` class is part of the sample project used in this guide, not the default class generated by Spring Initializr (which is `DemoApplication`).

This change helps avoid confusion for beginners who follow the guide and expect their generated project to match the documentation exactly.

Fixes #163