### PR TITLE
docs: add Gradle and Maven build tabs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -181,7 +181,26 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/build_an_executable_jar_subhead.adoc[]
 
-include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/build_an_executable_jar_with_both.adoc[]
+You can run the application from the command line with Gradle or Maven. You can also build a single executable JAR file that contains all the necessary dependencies, classes, and resources and run that. Building an executable jar makes it easy to ship, version, and deploy the service as an application throughout the development lifecycle, across different environments, and so forth.
+
+====
+[subs="attributes", role="primary"]
+.Gradle
+----
+./gradlew bootRun
+./gradlew build
+java -jar build/libs/{project_id}-0.1.0.jar
+----
+[subs="attributes", role="secondary"]
+.Maven
+----
+./mvnw spring-boot:run
+./mvnw clean package
+java -jar target/{project_id}-0.1.0.jar
+----
+====
+
+NOTE: The steps described here create a runnable JAR. You can also https://docs.spring.io/spring-boot/docs/current/reference/html/how-to/deployment/traditional-deployment.html#howto.traditional-deployment.war[build a classic WAR file].
 
 Logging output is displayed. The service should be up and running within a few seconds.
 


### PR DESCRIPTION
## Summary
- Add tabbed Gradle and Maven build instructions in the RESTful Web Service guide
- Align build steps with the existing Java/Kotlin tabbed examples

## Testing
- Not applicable (documentation change)

Related: spring-guides/getting-started-guides#170