### PR TITLE
Fix package name used by pre-initialized project link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,7 +50,7 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 [[scratch]]
 == Starting with Spring Initializr
 
-You can use this https://start.spring.io/#!type=gradle-project&language=java&packaging=jar&groupId=com.example&artifactId=rest-service&name=rest-service&packageName=com.example.rest-service&dependencies=web[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
+You can use this https://start.spring.io/#!type=gradle-project&language=java&packaging=jar&groupId=com.example&artifactId=rest-service&name=rest-service&packageName=com.example.restservice&dependencies=web[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
 
 To manually initialize the project:
 


### PR DESCRIPTION
## Summary
- Update the pre-initialized project link to use `com.example.restservice`
- Ensure generated package path matches the guide examples

## Testing
- Not applicable (documentation change)

Related: spring-guides/gs-spring-boot#195